### PR TITLE
cron bug fix

### DIFF
--- a/bin/rwall
+++ b/bin/rwall
@@ -145,5 +145,13 @@ then
 	fi
 fi
 
+# Set $DBUS_SESSION_BUS_ADDRESS enviroment variable if it is not set
+if [ -z "$DBUS_SESSION_BUS_ADDRESS" ]
+then
+    PID=$(pidof "cinnamon-session")
+    export DBUS_SESSION_BUS_ADDRESS=$(grep -z DBUS_SESSION_BUS_ADDRESS /proc/$PID/environ|cut -d= -f2-)
+fi
+
 # Change the wallpaper
 gsettings set org.gnome.desktop.background picture-uri "file://$rwall_root_directory/tmp/wallpaper-$id.$file_type"
+


### PR DESCRIPTION
The wallpaper is not changed when the script is run as a cron job in Linux Mint Cinnamon 17.2. The reason is that the `$DBUS_SESSION_BUS_ADDRESS` enviroment variable is not set in cron. The following code fixes the issues for me.