### PR TITLE
Fix search

### DIFF
--- a/bin/rwall
+++ b/bin/rwall
@@ -109,7 +109,7 @@ mkdir -p tmp
 rm -r tmp/*
 
 # Read the ini file for parameters
-q=$(grep q= etc/rwall.ini | cut -f2- -d '=')
+q=$(grep q= etc/rwall.ini | cut -f2- -d '=' | sed 's/, /\n/g' | shuf -n1)
 res=$(grep res= etc/rwall.ini | cut -f2- -d '=')
 
 # Download the html based on our search parameters


### PR DESCRIPTION
Currently when searching with e.g. the search string

https://wallhaven.cc/search?q=landscape%2C+minimalism%2C+abstract%2C+science+fiction&categories=111&purity=100&resolutions=1920x1080&sorting=random&order=asc

Rwall returns no wallpaper search results. Not sure what changed, but this fix
works around the issue by selecting a single category and using that, instead of
using all of the categories in the same query.